### PR TITLE
Add semantic version comparison.

### DIFF
--- a/bin/version-compare.sh
+++ b/bin/version-compare.sh
@@ -14,7 +14,7 @@ fi
 
 if dpkg --compare-versions $1 $3 $2
 then
-	echo "result=$(echo true)" >> $GITHUB_OUTPUT
+	echo "result=true" >> $GITHUB_OUTPUT
 else
-	echo "result=$(echo false)" >> $GITHUB_OUTPUT
+	echo "result=false" >> $GITHUB_OUTPUT
 fi

--- a/bin/version-compare.sh
+++ b/bin/version-compare.sh
@@ -4,12 +4,12 @@ version_compare () {
     if [[ $1 == 'latest' ]] || [[ $1 == 'dev' ]] || [[ $1 == 'nightly' ]]
     then
 		# Set first arg to a huge number considering latest, dev or nightly to be the highest version.
-        set -- 1000000 "${@:2:3}"
+        set -- 1000000 "${@:2}"
     fi
     if [[ $2 == 'latest' ]] || [[ $2 == 'dev' ]] || [[ $2 == 'nightly' ]]
     then
 		# Set second arg to a huge number considering latest, dev or nightly to be the highest version.
-        set -- "${@:1}" 1000000 "${@:3}"
+        set -- "${@:1:1}" 1000000
     fi
     if [[ $1 == $2 ]]
     then
@@ -49,7 +49,9 @@ case $? in
 esac
 if [[ $op != $3 ]]
 then
-	echo "result=$(echo false)" >> $GITHUB_OUTPUT
+	# echo "result=$(echo false)" >> $GITHUB_OUTPUT
+	echo false
 else
-	echo "result=$(echo true)" >> $GITHUB_OUTPUT
+	# echo "result=$(echo true)" >> $GITHUB_OUTPUT
+	echo true
 fi

--- a/bin/version-compare.sh
+++ b/bin/version-compare.sh
@@ -1,53 +1,18 @@
 #!/bin/bash
 
-version_compare () {
-    if [[ $1 == 'latest' ]] || [[ $1 == 'dev' ]] || [[ $1 == 'nightly' ]]
-    then
-		# Set first arg to a huge number considering latest, dev or nightly to be the highest version.
-        set -- 1000000 "${@:2}"
-    fi
-    if [[ $2 == 'latest' ]] || [[ $2 == 'dev' ]] || [[ $2 == 'nightly' ]]
-    then
-		# Set second arg to a huge number considering latest, dev or nightly to be the highest version.
-        set -- "${@:1:1}" 1000000
-    fi
-    if [[ $1 == $2 ]]
-    then
-        return 0
-    fi
-    local IFS=.
-    local i ver1=($1) ver2=($2)
-    # Fill empty fields in ver1 with zeros.
-    for ((i=${#ver1[@]}; i<${#ver2[@]}; i++))
-    do
-        ver1[i]=0
-    done
-    for ((i=0; i<${#ver1[@]}; i++))
-    do
-        if [[ -z ${ver2[i]} ]]
-        then
-            # Fill empty fields in ver2 with zeros.
-            ver2[i]=0
-        fi
-        if ((10#${ver1[i]} > 10#${ver2[i]}))
-        then
-            return 1
-        fi
-        if ((10#${ver1[i]} < 10#${ver2[i]}))
-        then
-            return 2
-        fi
-    done
-    return 0
-}
+if [[ $1 == 'latest' ]] || [[ $1 == 'dev' ]] || [[ $1 == 'nightly' ]]
+then
+	# Set first arg to a huge number considering latest, dev or nightly to be the highest version.
+	set -- 1000000 $2 $3
+fi
 
-version_compare $1 $2
-case $? in
-	0) op='=';;
-	1) op='>';;
-	2) op='<';;
-esac
-if [[ $op != $3 ]]
+if [[ $2 == 'latest' ]] || [[ $2 == 'dev' ]] || [[ $2 == 'nightly' ]]
+then
+	# Set second arg to a huge number considering latest, dev or nightly to be the highest version.
+	set -- $1 1000000 $3
+fi
+
+if dpkg --compare-versions $1 $3 $2
 then
 	echo "result=$(echo false)" >> $GITHUB_OUTPUT
 else

--- a/bin/version-compare.sh
+++ b/bin/version-compare.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+version_compare () {
+    if [[ $1 == 'latest' ]] || [[ $1 == 'dev' ]] || [[ $1 == 'nightly' ]]
+    then
+		# Set first arg to a huge number considering latest, dev or nightly to be the highest version.
+        set -- 1000000 "${@:2:3}"
+    fi
+    if [[ $2 == 'latest' ]] || [[ $2 == 'dev' ]] || [[ $2 == 'nightly' ]]
+    then
+		# Set second arg to a huge number considering latest, dev or nightly to be the highest version.
+        set -- "${@:1}" 1000000 "${@:3}"
+    fi
+    if [[ $1 == $2 ]]
+    then
+        return 0
+    fi
+    local IFS=.
+    local i ver1=($1) ver2=($2)
+    # Fill empty fields in ver1 with zeros.
+    for ((i=${#ver1[@]}; i<${#ver2[@]}; i++))
+    do
+        ver1[i]=0
+    done
+    for ((i=0; i<${#ver1[@]}; i++))
+    do
+        if [[ -z ${ver2[i]} ]]
+        then
+            # Fill empty fields in ver2 with zeros.
+            ver2[i]=0
+        fi
+        if ((10#${ver1[i]} > 10#${ver2[i]}))
+        then
+            return 1
+        fi
+        if ((10#${ver1[i]} < 10#${ver2[i]}))
+        then
+            return 2
+        fi
+    done
+    return 0
+}
+
+version_compare $1 $2
+case $? in
+	0) op='=';;
+	1) op='>';;
+	2) op='<';;
+esac
+if [[ $op != $3 ]]
+then
+	echo "result=$(echo false)" >> $GITHUB_OUTPUT
+else
+	echo "result=$(echo true)" >> $GITHUB_OUTPUT
+fi

--- a/bin/version-compare.sh
+++ b/bin/version-compare.sh
@@ -14,7 +14,7 @@ fi
 
 if dpkg --compare-versions $1 $3 $2
 then
-	echo "result=$(echo false)" >> $GITHUB_OUTPUT
-else
 	echo "result=$(echo true)" >> $GITHUB_OUTPUT
+else
+	echo "result=$(echo false)" >> $GITHUB_OUTPUT
 fi

--- a/bin/version-compare.sh
+++ b/bin/version-compare.sh
@@ -49,9 +49,7 @@ case $? in
 esac
 if [[ $op != $3 ]]
 then
-	# echo "result=$(echo false)" >> $GITHUB_OUTPUT
-	echo false
+	echo "result=$(echo false)" >> $GITHUB_OUTPUT
 else
-	# echo "result=$(echo true)" >> $GITHUB_OUTPUT
-	echo true
+	echo "result=$(echo true)" >> $GITHUB_OUTPUT
 fi

--- a/phpunit/action.yml
+++ b/phpunit/action.yml
@@ -30,9 +30,16 @@ runs:
         coverage: none
         php-version: ${{ inputs.php-version }}
 
-    - name: Clean PHP Dependencies
+    - name: Check version requirement
+      id: version-compare
+      uses: polylang/actions/version-compare@ver-comp
+      with:
+        head: ${{ inputs.wordpress-version }}
+        base: "5.9"
+
+    - name: Clean PHP dependencies
       run: |
-        if [[ ${{ inputs.wordpress-version }} == "5.8.x" ]]; then
+        if [[ ${{ steps.version-compare.outputs.result }} == true ]]; then
           composer require --no-interaction --no-update --ignore-platform-reqs --dev "phpunit/phpunit ^7.5"
         fi
         composer remove --no-interaction --no-update --dev "phpstan/phpstan"

--- a/phpunit/action.yml
+++ b/phpunit/action.yml
@@ -57,7 +57,10 @@ runs:
         version: ${{ inputs.wordpress-version }}
 
     - name: Set up plugins and themes dependencies
-      run: "bash ./tests/bin/install-plugins.sh"
+      run: |
+        if [[ -f ./tests/bin/install-plugins.sh ]]; then
+          bash ./tests/bin/install-plugins.sh
+        fi
       shell: bash
 
     - name: Run PHPUnit tests

--- a/version-compare/action.yml
+++ b/version-compare/action.yml
@@ -12,10 +12,10 @@ inputs:
     required: true
     type: string
   operator:
-    description: Operator, accepts '<', '>' and '='. Default to '<'.
+    description: Operator, accepts 'lt', 'gt' and 'eq'. Default to 'lt'.
     required: true
     type: string
-    default: '<'
+    default: 'lt'
 
 outputs:
   result:

--- a/version-compare/action.yml
+++ b/version-compare/action.yml
@@ -1,0 +1,35 @@
+name: Sementic Versions Compare
+
+description: Compares two versions. If 'dev', 'nightly' or 'latest' is given it'll be considered as the highest version possible.
+
+inputs:
+  head:
+    description: First version number.
+    required: true
+    type: string
+  base:
+    description: Second version number.
+    required: true
+    type: string
+  operator:
+    description: Operator, accepts '<', '>' and '='. Default to '<'.
+    required: true
+    type: string
+    default: '<'
+
+outputs:
+  result:
+    description: Whether or not the version comparison it correct.
+    value: ${{ steps.compare.outputs.result }}
+
+permissions:
+  contents: read
+
+runs:
+  using: 'composite'
+
+  steps:
+  - name: Compare versions
+    id: compare
+    run: bash ${{ github.action_path }}/../bin/version-compare.sh "${{ inputs.head }}" "${{ inputs.base }}" "${{ inputs.operator }}"
+    shell: bash

--- a/version-compare/action.yml
+++ b/version-compare/action.yml
@@ -13,7 +13,7 @@ inputs:
     type: string
   operator:
     description: Operator, accepts 'lt', 'gt' and 'eq'. Default to 'lt'.
-    required: true
+    required: false
     type: string
     default: 'lt'
 


### PR DESCRIPTION
## What?
Fixes https://github.com/polylang/actions/issues/1
Allow third party to run PHPUnit test for old WordPress version which requires old PHPUnit versions.
Use semantic version comparison to achieve that.

## How?
- Create a new action `version-compare` to compare to versions with a optional operator (default to "<").
- This action accepts "dev", "latest" and "nightly" as version and assume they're the highest version.
- Use this new `version-compare` action in `phpunit` action to require the correct PHPUnit version depending on the current WordPress veersion.

## Limits
The version compare action is not able to correctly compare two versions if "dev", "latest" or "nightly" is passed for *both* versions.