### PR TITLE
Reorder static analysis

### DIFF
--- a/static-analysis/action.yml
+++ b/static-analysis/action.yml
@@ -20,10 +20,10 @@ runs:
     with:
       dependency-versions: 'highest'
 
-  - name: Run PHPCS
-    run: vendor/bin/phpcs
-    shell: bash
-
   - name: Run PHPStan
     run: vendor/bin/phpstan analyze --memory-limit=1500M
+    shell: bash
+
+  - name: Run PHPCS
+    run: vendor/bin/phpcs
     shell: bash


### PR DESCRIPTION
In GHA every step will halt execution.

Swap phpcs and phpstan because phpcs usually reports minor errors then phpstan would not run at all.

From https://github.com/polylang/polylang/pull/1476/checks