### PR TITLE
Update dependencies to avoid Node depreciation notices in external jobs.

### DIFF
--- a/e2e/action.yml
+++ b/e2e/action.yml
@@ -32,7 +32,7 @@ runs:
         php-version: '8.0'
 
     - name: Install PHP Dependencies
-      uses: ramsey/composer-install@v2
+      uses: ramsey/composer-install@v3
       with:
         dependency-versions: 'highest'
         composer-options: '--no-dev'

--- a/phpunit/action.yml
+++ b/phpunit/action.yml
@@ -52,7 +52,7 @@ runs:
         dependency-versions: 'highest'
 
     - name: Set up WordPress ${{ inputs.wordpress-version }} and WordPress Test Library
-      uses: sjinks/setup-wordpress-test-library@v2
+      uses: sjinks/setup-wordpress-test-library@v2.1.1
       with:
         version: ${{ inputs.wordpress-version }}
 

--- a/phpunit/action.yml
+++ b/phpunit/action.yml
@@ -52,7 +52,7 @@ runs:
         dependency-versions: 'highest'
 
     - name: Set up WordPress ${{ inputs.wordpress-version }} and WordPress Test Library
-      uses: sjinks/setup-wordpress-test-library@2.1.1
+      uses: sjinks/setup-wordpress-test-library@v2.1.1
       with:
         version: ${{ inputs.wordpress-version }}
 

--- a/phpunit/action.yml
+++ b/phpunit/action.yml
@@ -52,7 +52,7 @@ runs:
         dependency-versions: 'highest'
 
     - name: Set up WordPress ${{ inputs.wordpress-version }} and WordPress Test Library
-      uses: sjinks/setup-wordpress-test-library@1.1.19
+      uses: sjinks/setup-wordpress-test-library@2.1.1
       with:
         version: ${{ inputs.wordpress-version }}
 

--- a/phpunit/action.yml
+++ b/phpunit/action.yml
@@ -47,7 +47,7 @@ runs:
       shell: bash
 
     - name: Install PHP Dependencies
-      uses: ramsey/composer-install@v2
+      uses: ramsey/composer-install@v3
       with:
         dependency-versions: 'highest'
 

--- a/phpunit/action.yml
+++ b/phpunit/action.yml
@@ -52,7 +52,7 @@ runs:
         dependency-versions: 'highest'
 
     - name: Set up WordPress ${{ inputs.wordpress-version }} and WordPress Test Library
-      uses: sjinks/setup-wordpress-test-library@v2.1.1
+      uses: sjinks/setup-wordpress-test-library@v2
       with:
         version: ${{ inputs.wordpress-version }}
 

--- a/static-analysis/action.yml
+++ b/static-analysis/action.yml
@@ -16,7 +16,7 @@ runs:
       php-version: '8.0'
 
   - name: Install PHP Dependencies
-    uses: ramsey/composer-install@v2
+    uses: ramsey/composer-install@v3
     with:
       dependency-versions: 'highest'
 


### PR DESCRIPTION
## Why?
Avoid depreciation notices in for Node version in Github actions runner for jobs using our actions.

## How?
Update `sjinks/setup-wordpress-test-library` and `ramsey/composer-install`.