### PR TITLE
Install SVN.

### DIFF
--- a/phpunit/action.yml
+++ b/phpunit/action.yml
@@ -57,8 +57,8 @@ runs:
         sudo apt-get update
         sudo apt-get install -y subversion
 
-  - name: Has SVN?
-    run: which svn || exit 1
+    - name: Has SVN?
+      run: which svn || exit 1
 
     - name: Set up WordPress ${{ inputs.wordpress-version }} and WordPress Test Library
       uses: sjinks/setup-wordpress-test-library@v2.1.3

--- a/phpunit/action.yml
+++ b/phpunit/action.yml
@@ -51,6 +51,15 @@ runs:
       with:
         dependency-versions: 'highest'
 
+    - name: Install SVN
+      # SVN is required by sjinks/setup-wordpress-test-library.
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y subversion
+
+  - name: Has SVN?
+    run: which svn || exit 1
+
     - name: Set up WordPress ${{ inputs.wordpress-version }} and WordPress Test Library
       uses: sjinks/setup-wordpress-test-library@v2.1.3
       with:


### PR DESCRIPTION
## What?
GitHub runner default Ubuntu version is now 24.04, which isn't shipped with SVN.
See https://github.com/actions/runner-images/issues/10636
But SVN is required to install WordPress test suite in `sjinks/setup-wordpress-test-library`.

## How?
- Install SVN in a new step of the PHPUnit action.
- Ensure it is installed correctly before going further.