### PR TITLE
Allow package release info change in PHPUnit CI.

### DIFF
--- a/phpunit/action.yml
+++ b/phpunit/action.yml
@@ -24,21 +24,6 @@ runs:
   using: 'composite'
 
   steps:
-    - name: Prepare environment for APT
-      run: |
-        # Creating apt config files
-        echo 'APT::Get::AllowReleaseInfoChange "true";' | sudo tee /etc/apt/apt.conf.d/99allow-release-info-change
-        echo 'APT::Key::Assert-Pubkey-Algo ">=rsa1024";' | sudo tee /etc/apt/apt.conf.d/99weakkey-warning
-        # Set environment variable to ignore the label changes
-        echo "DEBIAN_FRONTEND=noninteractive" >> $GITHUB_ENV
-        # Apply settings for existing apt config
-        sudo sed -i 's/^APT::Get::AllowReleaseInfoChange.*$/APT::Get::AllowReleaseInfoChange "true";/' /etc/apt/apt.conf 2>/dev/null || true
-      shell: bash
-
-    - name: Update apt repositories
-      run: sudo DEBIAN_FRONTEND=noninteractive apt-get update -y --allow-releaseinfo-change
-      shell: bash
-
     - name: Set up PHP ${{ inputs.php-version }}
       uses: shivammathur/setup-php@v2
       with:
@@ -69,8 +54,8 @@ runs:
     - name: Install SVN
       # SVN is required by sjinks/setup-wordpress-test-library.
       run: |
-        sudo DEBIAN_FRONTEND=noninteractive apt-get update -y --allow-releaseinfo-change
-        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y subversion
+        sudo apt-get update -y --allow-releaseinfo-change
+        sudo apt-get install -y subversion
         svn --version
       shell: bash
 

--- a/phpunit/action.yml
+++ b/phpunit/action.yml
@@ -24,14 +24,19 @@ runs:
   using: 'composite'
 
   steps:
-    - name: Configure APT to handle repository changes and weak keys
+    - name: Prepare environment for APT
       run: |
+        # Creating apt config files
         echo 'APT::Get::AllowReleaseInfoChange "true";' | sudo tee /etc/apt/apt.conf.d/99allow-release-info-change
         echo 'APT::Key::Assert-Pubkey-Algo ">=rsa1024";' | sudo tee /etc/apt/apt.conf.d/99weakkey-warning
+        # Set environment variable to ignore the label changes
+        echo "DEBIAN_FRONTEND=noninteractive" >> $GITHUB_ENV
+        # Apply settings for existing apt config
+        sudo sed -i 's/^APT::Get::AllowReleaseInfoChange.*$/APT::Get::AllowReleaseInfoChange "true";/' /etc/apt/apt.conf 2>/dev/null || true
       shell: bash
 
     - name: Update apt repositories
-      run: sudo apt-get update -y
+      run: sudo DEBIAN_FRONTEND=noninteractive apt-get update -y --allow-releaseinfo-change
       shell: bash
 
     - name: Set up PHP ${{ inputs.php-version }}
@@ -64,8 +69,8 @@ runs:
     - name: Install SVN
       # SVN is required by sjinks/setup-wordpress-test-library.
       run: |
-        sudo apt-get update -y
-        sudo apt-get install -y subversion
+        sudo DEBIAN_FRONTEND=noninteractive apt-get update -y --allow-releaseinfo-change
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y subversion
         svn --version
       shell: bash
 

--- a/phpunit/action.yml
+++ b/phpunit/action.yml
@@ -24,8 +24,14 @@ runs:
   using: 'composite'
 
   steps:
-    - name: Update apt repositories with --allow-releaseinfo-change
-      run: sudo apt-get update -y --allow-releaseinfo-change
+    - name: Configure APT to handle repository changes and weak keys
+      run: |
+        echo 'APT::Get::AllowReleaseInfoChange "true";' | sudo tee /etc/apt/apt.conf.d/99allow-release-info-change
+        echo 'APT::Key::Assert-Pubkey-Algo ">=rsa1024";' | sudo tee /etc/apt/apt.conf.d/99weakkey-warning
+      shell: bash
+
+    - name: Update apt repositories
+      run: sudo apt-get update -y
       shell: bash
 
     - name: Set up PHP ${{ inputs.php-version }}
@@ -58,7 +64,7 @@ runs:
     - name: Install SVN
       # SVN is required by sjinks/setup-wordpress-test-library.
       run: |
-        sudo apt-get update -y --allow-releaseinfo-change
+        sudo apt-get update -y
         sudo apt-get install -y subversion
         svn --version
       shell: bash

--- a/phpunit/action.yml
+++ b/phpunit/action.yml
@@ -24,6 +24,10 @@ runs:
   using: 'composite'
 
   steps:
+    - name: Update apt repositories with --allow-releaseinfo-change
+      run: sudo apt-get update -y --allow-releaseinfo-change
+      shell: bash
+
     - name: Set up PHP ${{ inputs.php-version }}
       uses: shivammathur/setup-php@v2
       with:
@@ -54,7 +58,7 @@ runs:
     - name: Install SVN
       # SVN is required by sjinks/setup-wordpress-test-library.
       run: |
-        sudo apt-get update
+        sudo apt-get update -y --allow-releaseinfo-change
         sudo apt-get install -y subversion
         svn --version
       shell: bash


### PR DESCRIPTION
## What?
Fixes errors like:
```bash
E: Repository 'https://ppa.launchpadcontent.net/ondrej/php/ubuntu noble InRelease' changed its 'Label' value from '***** The main PPA for supported PHP versions with many PECL extensions *****' to 'PPA for PHP'
```

## How?
Use the flag `--allow-releaseinfo-change` with APT.