### PR TITLE
Cache Node modules and Playwright binaries during e2e tests setup.

### DIFF
--- a/e2e/action.yml
+++ b/e2e/action.yml
@@ -83,20 +83,17 @@ runs:
         echo "WP_VERSION=$(node -e "fetch('https://api.wordpress.org/core/version-check/1.7/').then(r => r.json()).then(data => console.log(data.offers[0].current))")" >> $GITHUB_ENV
       shell: bash
 
-    - name: Check wp-env cached container
+    - name: Cache wp-env Docker image
+      id: docker-cache
       uses: actions/cache@v4
-      id: wp-env-cache
       with:
-        path: |
-          ~/.cache/wp-env-backup
+        path: wp-env-image.tar
         key: ${{ runner.os }}-wp-env-${{ env.WP_VERSION }}-${{ inputs.container-cache-key }}
 
-    - name: Restore wp-env container
-      if: steps.wp-env-cache.outputs.cache-hit == 'true'
+    - name: Load cached Docker image (if any)
+      if: steps.docker-cache.outputs.cache-hit == 'true'
       run: |
-        mkdir -p ~/wp-env/
-        cp -r ~/.cache/wp-env-backup/* ~/wp-env/
-      shell: bash
+        docker load -i wp-env-image.tar
 
     - name: Install WordPress and start the server
       run: |
@@ -104,6 +101,12 @@ runs:
       shell: bash
       env:
         WP_ENV_PHP_VERSION: '8.0'
+
+    - name: Save Docker image to cache
+      if: steps.docker-cache.outputs.cache-hit != 'true'
+      run: |
+        docker image ls
+        docker save $(docker images --format '{{.Repository}}:{{.Tag}}' | grep 'wp-env') -o wp-env-image.tar
 
     - name: Cache wp-env container
       if: steps.wp-env-cache.outputs.cache-hit != 'true'

--- a/e2e/action.yml
+++ b/e2e/action.yml
@@ -39,7 +39,7 @@ runs:
     - name: Get installed Playwright version
       id: playwright-version
       run: |
-        echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').devDependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+        echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages.devDependencies['@playwright/test'].version)")" >> $GITHUB_ENV
       shell: bash
 
     - name: Cache Playwright binaries

--- a/e2e/action.yml
+++ b/e2e/action.yml
@@ -13,16 +13,47 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version: 22
-    - run: npm install
-      shell: bash
-    - run: npm run build --if-present
+
+    - name: Set up package-lock.json
+      run: |
+        npm install --package-lock-only
       shell: bash
 
-    - name: Install Playwright dependencies
-        # Only Chromium for the moment.
+    - name: Cache node_modules
+      id: cache-node_modules
+      uses: actions/cache@v4
+      with:
+          path: '**/node_modules'
+          key: node_modules-${{ runner.os }}-${{ runner.arch }}-${{ steps.node-version.outputs.NODE_VERSION }}-${{ hashFiles('package-lock.json') }}
+
+    - name: Install dependencies
+      if: ${{ steps.cache-node_modules.outputs.cache-hit != 'true' }}
+      run: |
+          npm install
+      shell: bash
+
+    - name: Build dependencies
+      run: npm run build --if-present
+      shell: bash
+
+    - name: Get installed Playwright version
+      id: playwright-version
+      run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+
+    - name: Cache Playwright binaries
+      uses: actions/cache@v3
+      id: playwright-cache
+      with:
+        path: |
+          ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+
+    - name: Install Playwright binaries
+      # Only Chromium for the moment.
       run: |
         npx playwright install chromium --with-deps
       shell: bash
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
 
     # Must install PHP deps before wp-env is running to prevent errors.
     - name: Set up PHP

--- a/e2e/action.yml
+++ b/e2e/action.yml
@@ -39,8 +39,7 @@ runs:
     - name: Get installed Playwright version
       id: playwright-version
       run: |
-        node -e "console.log(require('./package-lock.json').packages)"
-        echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages.dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+        echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_ENV
       shell: bash
 
     - name: Cache Playwright binaries

--- a/e2e/action.yml
+++ b/e2e/action.yml
@@ -38,7 +38,8 @@ runs:
 
     - name: Get installed Playwright version
       id: playwright-version
-      run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+      run: |
+        echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').devDependencies['@playwright/test'].version)")" >> $GITHUB_ENV
       shell: bash
 
     - name: Cache Playwright binaries

--- a/e2e/action.yml
+++ b/e2e/action.yml
@@ -94,6 +94,7 @@ runs:
       if: steps.docker-cache.outputs.cache-hit == 'true'
       run: |
         docker load -i wp-env-image.tar
+      shell: bash
 
     - name: Install WordPress and start the server
       run: |
@@ -107,11 +108,6 @@ runs:
       run: |
         docker image ls
         docker save $(docker images --format '{{.Repository}}:{{.Tag}}' | grep 'wp-env') -o wp-env-image.tar
-
-    - name: Cache wp-env container
-      if: steps.wp-env-cache.outputs.cache-hit != 'true'
-      run: |
-        cp -r ~/wp-env/* ~/.cache/wp-env-backup/
       shell: bash
 
     - name: Run Playwright tests

--- a/e2e/action.yml
+++ b/e2e/action.yml
@@ -39,7 +39,7 @@ runs:
     - name: Get installed Playwright version
       id: playwright-version
       run: |
-        echo "(node -e "console.log(require('./package-lock.json').packages))"
+        node -e "console.log(require('./package-lock.json').packages)"
         echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages.dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
       shell: bash
 

--- a/e2e/action.yml
+++ b/e2e/action.yml
@@ -16,7 +16,7 @@ runs:
 
     - name: Set up package-lock.json
       run: |
-        npm install --package-lock-only
+        npm install --package-lock-only --no-audit --only=prod
       shell: bash
 
     - name: Cache node_modules
@@ -29,7 +29,7 @@ runs:
     - name: Install dependencies
       if: ${{ steps.cache-node_modules.outputs.cache-hit != 'true' }}
       run: |
-          npm install
+          npm ci
       shell: bash
 
     - name: Build dependencies

--- a/e2e/action.yml
+++ b/e2e/action.yml
@@ -39,6 +39,7 @@ runs:
     - name: Get installed Playwright version
       id: playwright-version
       run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+      shell: bash
 
     - name: Cache Playwright binaries
       uses: actions/cache@v3

--- a/e2e/action.yml
+++ b/e2e/action.yml
@@ -17,7 +17,7 @@ runs:
 
   steps:
     - name: Setup Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 22
 

--- a/e2e/action.yml
+++ b/e2e/action.yml
@@ -107,7 +107,7 @@ runs:
       if: steps.docker-cache.outputs.cache-hit != 'true'
       run: |
         docker image ls
-        docker save $(docker images --format '{{.Repository}}:{{.Tag}}' | grep 'wp-env') -o wp-env-image.tar
+        docker save $(docker images --format '{{.Repository}}:{{.Tag}}') -o wp-env-image.tar
       shell: bash
 
     - name: Run Playwright tests

--- a/e2e/action.yml
+++ b/e2e/action.yml
@@ -68,7 +68,7 @@ runs:
       uses: ramsey/composer-install@v3
       with:
         dependency-versions: 'highest'
-        composer-options: '--no-dev'
+        composer-options: '--no-dev --optimize-autoloader'
 
     - name: Install WordPress and start the server
       run: |

--- a/e2e/action.yml
+++ b/e2e/action.yml
@@ -39,7 +39,8 @@ runs:
     - name: Get installed Playwright version
       id: playwright-version
       run: |
-        echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages.devDependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+        echo "(node -e "console.log(require('./package-lock.json').packages)"
+        echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages.dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
       shell: bash
 
     - name: Cache Playwright binaries

--- a/e2e/action.yml
+++ b/e2e/action.yml
@@ -39,7 +39,7 @@ runs:
     - name: Get installed Playwright version
       id: playwright-version
       run: |
-        echo "(node -e "console.log(require('./package-lock.json').packages)"
+        echo "(node -e "console.log(require('./package-lock.json').packages))"
         echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages.dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
       shell: bash
 

--- a/e2e/action.yml
+++ b/e2e/action.yml
@@ -50,7 +50,7 @@ runs:
       shell: bash
 
     - name: Cache Playwright binaries
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: playwright-cache
       with:
         path: |

--- a/e2e/action.yml
+++ b/e2e/action.yml
@@ -94,6 +94,7 @@ runs:
     - name: Restore wp-env container
       if: steps.wp-env-cache.outputs.cache-hit == 'true'
       run: |
+        mkdir -p ~/wp-env/
         cp -r ~/.cache/wp-env-backup/* ~/wp-env/
       shell: bash
 

--- a/e2e/action.yml
+++ b/e2e/action.yml
@@ -16,7 +16,7 @@ runs:
 
     - name: Set up package-lock.json
       run: |
-        npm install --package-lock-only --no-audit --only=prod
+        npm install --package-lock-only --no-audit
       shell: bash
 
     - name: Cache node_modules

--- a/e2e/action.yml
+++ b/e2e/action.yml
@@ -2,6 +2,13 @@ name: Run Playwright e2e Tests
 
 description: Installs WordPress, starts the server, builds dependencies and run Playwright tests. Currently runs on PHP 8.0 with WordPress latest release.
 
+inputs:
+  container-cache-key:
+    description: Container cache key. Used to cache wp-env container.
+    required: false
+    type: string
+    default: 'no-external-cache-key'
+
 permissions:
   contents: read
 
@@ -70,12 +77,38 @@ runs:
         dependency-versions: 'highest'
         composer-options: '--no-dev --optimize-autoloader'
 
+    - name: Get WordPress latest version
+      id: wp-version
+      run: |
+        echo "WP_VERSION=$(node -e "fetch('https://api.wordpress.org/core/version-check/1.7/').then(r => r.json()).then(data => console.log(data.offers[0].current))")" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Check wp-env cached container
+      uses: actions/cache@v4
+      id: wp-env-cache
+      with:
+        path: |
+          ~/.cache/wp-env-backup
+        key: ${{ runner.os }}-wp-env-${{ env.WP_VERSION }}-${{ inputs.container-cache-key }}
+
+    - name: Restore wp-env container
+      if: steps.wp-env-cache.outputs.cache-hit == 'true'
+      run: |
+        cp -r ~/.cache/wp-env-backup/* ~/wp-env/
+      shell: bash
+
     - name: Install WordPress and start the server
       run: |
         npm run wp-env start
       shell: bash
       env:
         WP_ENV_PHP_VERSION: '8.0'
+
+    - name: Cache wp-env container
+      if: steps.wp-env-cache.outputs.cache-hit != 'true'
+      run: |
+        cp -r ~/wp-env/* ~/.cache/wp-env-backup/
+      shell: bash
 
     - name: Run Playwright tests
       run: |


### PR DESCRIPTION
## What?
All in the title.

## Why?
So e2e tests run faster in CI.