### PR TITLE
Remove `rector/rector` dependency when running PHPUnit.

### DIFF
--- a/phpunit/action.yml
+++ b/phpunit/action.yml
@@ -44,6 +44,7 @@ runs:
         fi
         composer remove --no-interaction --no-update --dev "phpstan/phpstan"
         composer remove --no-interaction --no-update --dev "wpsyntex/polylang-phpstan"
+        composer remove --no-interaction --no-update --dev "rector/rector"
       shell: bash
 
     - name: Install PHP Dependencies


### PR DESCRIPTION
## What?
Fixes CI errors in PHPUnit workflow such as https://github.com/polylang/polylang/actions/runs/19141024288/job/54705827771#step:4:183

## Why?
`rector/rector` requires PHP > 7.4, although some jobs run with PHP 7.2.

## How?
Remove `rector/rector` dependency in PHPUnit action.