### PR TITLE
Run composer install before npm build.

### DIFF
--- a/e2e/action.yml
+++ b/e2e/action.yml
@@ -39,6 +39,19 @@ runs:
           npm ci
       shell: bash
 
+    # Must install PHP deps before wp-env is running to prevent errors.
+    - name: Set up PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        coverage: none
+        php-version: '8.0'
+
+    - name: Install PHP Dependencies
+      uses: ramsey/composer-install@v3
+      with:
+        dependency-versions: 'highest'
+        composer-options: '--no-dev --optimize-autoloader'
+
     - name: Build dependencies
       run: npm run build --if-present
       shell: bash
@@ -63,19 +76,6 @@ runs:
         npx playwright install chromium --with-deps
       shell: bash
       if: steps.playwright-cache.outputs.cache-hit != 'true'
-
-    # Must install PHP deps before wp-env is running to prevent errors.
-    - name: Set up PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        coverage: none
-        php-version: '8.0'
-
-    - name: Install PHP Dependencies
-      uses: ramsey/composer-install@v3
-      with:
-        dependency-versions: 'highest'
-        composer-options: '--no-dev --optimize-autoloader'
 
     - name: Get WordPress latest version
       id: wp-version


### PR DESCRIPTION
## What
Reorder steps in the e2e action to run `composer install` before `npm run build`.

## Why
Currently, the action runs:
1. `npm run build`
2. `composer install`

This causes to skip all Polylang vendor files since the directory doesn't exist yet during the build step.
Any JS fixes in the Polylang dependency are never compiled.

## Fix
Move the PHP setup and composer install steps before the build step.

Now it should find and build all vendor JS files correctly.